### PR TITLE
Bugfix: Should highlight currently selected scene.

### DIFF
--- a/app-management/libs/shared/src/gcp/firestore.service.ts
+++ b/app-management/libs/shared/src/gcp/firestore.service.ts
@@ -86,7 +86,7 @@ export class FirestoreService {
     sceneArrayIndex?: string,
     addAfter?: boolean,
   ) {
-    const keysToDelete = ['id', 'createdAt']; // Add the keys you want to delete
+    const keysToDelete = ['createdAt']; // Add the keys you want to delete
 
     keysToDelete.forEach((key) => {
       delete data[key];


### PR DESCRIPTION
This pull request includes a small change to the `FirestoreService` class in the `app-management/libs/shared/src/gcp/firestore.service.ts` file. The change removes the `id` key from the `keysToDelete` array, leaving only the `createdAt` key for deletion. 

* [`app-management/libs/shared/src/gcp/firestore.service.ts`](diffhunk://#diff-fe499007d8a9698b07ce7e5326900995b6dedd9f6081c4e1c8e0cc02bcaafc4eL89-R89): Removed the `id` key from the `keysToDelete` array in the `FirestoreService` class.


--- 

Before this PR all scenes were displaying selected which was not expected. 

**Before** 

<img width="1028" alt="Screenshot 2024-11-18 at 6 52 50 AM" src="https://github.com/user-attachments/assets/b205fcca-4825-44e2-8213-2166a1858aad">


**After** 
<img width="1199" alt="Screenshot 2024-11-18 at 6 53 03 AM" src="https://github.com/user-attachments/assets/41393871-7b59-4046-abd0-cb90937b1e6f">

