### PR TITLE
curl installed in docker images

### DIFF
--- a/app-management/Dockerfile
+++ b/app-management/Dockerfile
@@ -2,6 +2,10 @@ FROM node:18 AS base
 
 WORKDIR /app
 
+# Install curl
+RUN apt-get update && apt-get install -y curl
+
+
 COPY apps ./apps
 COPY libs ./libs
 COPY nest-cli.json ./
@@ -16,6 +20,10 @@ RUN npm run build
 FROM node:18-alpine AS release
 # Create app directory
 WORKDIR /app
+
+# Install curl
+RUN apk add --no-cache curl
+
 # Install production dependencies
 COPY --from=BASE /app/package*.json ./
 RUN npm install --only=production


### PR DESCRIPTION
This pull request includes updates to the `app-management/Dockerfile` to install `curl` in both the base and release stages of the Docker build process.

Dockerfile updates:

* [`app-management/Dockerfile`](diffhunk://#diff-2102287a227a5827fa41c8d56df06f0a7d20516e702182e1d666813c0892440fR5-R8): Added commands to install `curl` in the base stage using `apt-get`.
* [`app-management/Dockerfile`](diffhunk://#diff-2102287a227a5827fa41c8d56df06f0a7d20516e702182e1d666813c0892440fR23-R26): Added commands to install `curl` in the release stage using `apk`.